### PR TITLE
Add default export from d.ts

### DIFF
--- a/decimal.d.ts
+++ b/decimal.d.ts
@@ -1,3 +1,5 @@
+export default Decimal;
+
 export declare class Decimal {
     /**
      * The Decimal constructor and exported function.


### PR DESCRIPTION
This commit fixes the problem that default export is not declared.

![image](https://user-images.githubusercontent.com/1896605/47030011-c2a2e880-d1a7-11e8-861c-b549d88b0eb4.png)
