### PR TITLE
Fix type imports

### DIFF
--- a/decimal.d.mts
+++ b/decimal.d.mts
@@ -1,4 +1,4 @@
-export = Decimal;
+export default Decimal;
 
 export declare class Decimal {
     /**

--- a/package.json
+++ b/package.json
@@ -20,7 +20,19 @@
     "type": "git",
     "url": "https://github.com/MikeMcl/decimal.js-light.git"
   },
-  "main": "decimal",
+  "exports": {
+	".": {
+		"import": {
+		  "types": "./decimal.d.mts",
+		  "default": "./decimal.mjs"
+		},
+		"require": {
+		  "types": "./decimal.d.ts",
+		  "default": "./decimal.js"
+		}
+	  }
+  },
+  "main": "decimal.js",
   "module": "decimal.mjs",
   "browser": "decimal.js",
   "types": "decimal.d.ts",


### PR DESCRIPTION
https://arethetypeswrong.github.io/?p=decimal.js-light%402.5.1

Without this change I get the error:

```
import { Decimal } from "decimal.js-light";
         ^

SyntaxError: The requested module 'decimal.js-light' does not provide an export named 'Decimal'
```

Fix types by copying `decimal.d.ts` to `decimal.d.mts`.

Test with: `npx @arethetypeswrong/cli@latest --pack .`